### PR TITLE
Changes allowing circular types

### DIFF
--- a/excel2sbol/excel2sbol/comp_column_functions.py
+++ b/excel2sbol/excel2sbol/comp_column_functions.py
@@ -416,6 +416,22 @@ class sbol_methods3:
 
     def types(self):
         # used to decide the molecule type in the converter function
+        cell = []
+
+        # Assuming that circular will come after molecule type column in most templates
+        if self.cell_val[0:4] == 'http':
+            if getattr(self.obj, self.sbol_term_suf)[0][0:4] == 'http':
+                cell.append(getattr(self.obj, self.sbol_term_suf)[0])
+                cell.append(self.cell_val)
+            elif self.sht_col == 'Circular':
+                cell.append(sbol3.SBO_DNA)
+                cell.append(self.cell_val)
+            else:
+                cell.append(self.cell_val)
+        else:
+            cell.append(self.cell_val)
+
+        setattr(self.obj, self.sbol_term_suf, cell)
         pass
 
     def displayId(self):

--- a/excel2sbol/excel2sbol/compiler_test.py
+++ b/excel2sbol/excel2sbol/compiler_test.py
@@ -197,7 +197,7 @@ def parse_objects3(col_read_df, to_convert, compiled_sheets,
             raise KeyError(f'The sheet "{sht}" has no column with sbol_objectType as type. Thus the following error was raised: {e}')
 
         try:
-            mol_type_col = sht_df.loc[col_read_df['SBOL Term'] == 'sbol_type']['Column Name'].values[0]
+            mol_type_col = sht_df.loc[col_read_df['SBOL Term'] == 'sbol_types']['Column Name'].values[0]
             mol_types = compiled_sheets[sht]['library'][mol_type_col]
         except IndexError:
             mol_types = None
@@ -215,6 +215,13 @@ def parse_objects3(col_read_df, to_convert, compiled_sheets,
                 varfunc = getattr(sbol3, obj_types[ind])
                 if obj_types[ind] == "Component":
                     if mol_types is not None:
+
+                        # Creating the list as a string, needs for conversion
+                        mol_new = []
+                        for mol in mol_types:
+                            mol_new.append(str(mol))
+                        mol_types = mol_new
+
                         obj = varfunc(sanitised_id, mol_types[ind])
                     else:
                         obj = varfunc(sanitised_id, sbol3.SBO_DNA)


### PR DESCRIPTION
Added implementation for having both a molecule types column and a circular types.
Small change in compiler_test.py which allows boolean values to be converted to strings for comparison on another sheet (e.g. molecule types or circular types)
Change in types function in comp_column_functions.py to allow multiple type URI values and allow the incorporation of a circular type to an object as well as a molecule type.